### PR TITLE
FIX, preventing the logic from nuking out already existing parameters.

### DIFF
--- a/code/controllers/WebServiceController.php
+++ b/code/controllers/WebServiceController.php
@@ -261,7 +261,7 @@ class WebServiceController extends Controller {
 		for ($i = 0, $c = count($bits); $i < $c; ) {
 			$key = $bits[$i];
 			$val = isset($bits[$i + 1]) ? $bits[$i + 1] : null;
-			if ($val) {
+			if ($val && !isset($allArgs[$key])) {
 				$allArgs[$key] = $val;
 			}
 			$i += 2;


### PR DESCRIPTION
Basically as the commit says. I had a unit test that was passing through parameters, however the "remaining bits" contained the same key (since the URL was the same as a parameter being passed through). This caused the parameters to be nuked out, when it should have checked to see whether they existed first.